### PR TITLE
Fix syntax error in mixins

### DIFF
--- a/sass/_mixins.sass
+++ b/sass/_mixins.sass
@@ -23,7 +23,7 @@
 		margin-left: $halfMargin
 		margin-right: $halfMargin
 	@else if ispixel($width)
-		$halfWidth: (unit($width) / 2
+		$halfWidth: (unit($width)) / 2
 		width: $width
 		margin-left: calc(50% - $halfWidth)
 		margin-right: calc(50% - $halfWidth)


### PR DESCRIPTION
Adds a missing `)`, allowing the `sass` to be compilable again.