### PR TITLE
Fix inline code padding in blog posts

### DIFF
--- a/sass/meta/sizes.sass
+++ b/sass/meta/sizes.sass
@@ -52,7 +52,7 @@ $button-small-box: (height: 2em, line-height: 2em)
 
 // Code
 $code-border-radius: 0.25em
-$code-box: (padding: $gap-min)
+$code-box: (padding: 0.1em)
 $pre-box: (padding: $gap-normal, margin: 0 0 $content-margin)
 
 // Keyboard


### PR DESCRIPTION
The padding around inline code elements in blog posts is huge and looks off (to the point of overlapping in successive lines and/or blocking parts of other words). This is an attempt at fixing this, but since I know nothing about web stuff I assume it's not the way to go.

Before:
![](https://i.imgur.com/pIT0c3h.png)

After:
![](https://i.imgur.com/udoAB9C.png)